### PR TITLE
dht22: fix a typo in the temperature mask again

### DIFF
--- a/lib/Dht/Dht.cpp
+++ b/lib/Dht/Dht.cpp
@@ -26,7 +26,7 @@ int16_t Dht::get_temperature(void)
         return INT16_MIN;
     }
 
-    t = _data[3] + ((_data[2] & 0x7E)<<8);
+    t = _data[3] + ((_data[2] & 0x7F)<<8);
 
     return (_data[2] & 0x80) ? -t : t;
 }


### PR DESCRIPTION
This is similar to commit a1f370c83bbe8a65cf9e13865bbea08ccf51e1f6
"dht22: fix a typo in the mask not to loose a bit in temperature"

Let's do the same in get_temperature in case one uses this API.